### PR TITLE
Don't write blank URLs

### DIFF
--- a/src/FileExport.js
+++ b/src/FileExport.js
@@ -31,7 +31,7 @@ async function exportFileBasedOnOldTags(file, tags) {
             if (chapter.title[0] == "_") {
                 chapterObject.tags.title = chapter.title.substring(1);
             }
-            if (chapter.hasOwnProperty('url')) {
+            if (chapter.hasOwnProperty('url') && chapter.url) {
                 chapterObject.tags.userDefinedUrl = {
                     url: chapter.url,
                 }


### PR DESCRIPTION
Currently `WXXX` frames are written even when no URL is set.