### PR TITLE
Use seconds for Podcast Namespace chapter JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -873,28 +873,27 @@
                 Export audio file
             </button>
             <button id="podloveButton" class="btn btn-lg btn-outline-secondary">
-                Get JSON or Podlove XML
+                Get Podlove XML/Podcast Namespace JSON
             </button>
         </div>
         <details class="card mt-3 d-none" id="podlove">
             <summary class="card-header">
-                Podcast Chapter JSON format and Podlove Simple Chapters XML
+                Podlove Simple Chapters XML and Podcast Namespace JSON
             </summary>
             <div class="card-body">
                 <p>
                     Besides embedded ID3 chapters, other standards for specifying chapters exist.
                     Examples are the
-                    <a href="https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md">Podcast
+                    <a href="https://podlove.org/simple-chapters/">Podlove Simple Chapters XML</a> and
+                    <a href="https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md">Podcast Namespace
                         Chapter JSON</a>
-                    and
-                    <a href="https://podlove.org/simple-chapters/">Podlove Simple Chapters XML</a>
                     formats, which can be added to a podcast RSS feed via embedding into the <code>&lt;item&gt;</code>
                     tag (XML)
                     or by adding a link (JSON, XML).
                     While most podcast players use embedded chapters,
                     some other players (notably <a class="alert-link fw-normal"
                         href="https://support.spotify.com/bb/podcasters/article/enabling-podcast-chapters/">Spotify</a>)
-                    only support time stamps in the episode description or podlove chapters.
+                    only support time stamps in the episode description or Podlove chapters.
                 </p>
 
                 <div class="form-check form-switch">
@@ -917,7 +916,7 @@
                                 <path
                                     d="M1.5 0h11.586a1.5 1.5 0 0 1 1.06.44l1.415 1.414A1.5 1.5 0 0 1 16 2.914V14.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13A1.5 1.5 0 0 1 1.5 0M1 1.5v13a.5.5 0 0 0 .5.5H2v-4.5A1.5 1.5 0 0 1 3.5 9h9a1.5 1.5 0 0 1 1.5 1.5V15h.5a.5.5 0 0 0 .5-.5V2.914a.5.5 0 0 0-.146-.353l-1.415-1.415A.5.5 0 0 0 13.086 1H13v4.5A1.5 1.5 0 0 1 11.5 7h-7A1.5 1.5 0 0 1 3 5.5V1H1.5a.5.5 0 0 0-.5.5m3 4a.5.5 0 0 0 .5.5h7a.5.5 0 0 0 .5-.5V1H4zM3 15h10v-4.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5z" />
                             </svg>
-                            Download all images as a zip file
+                            Download all images as a ZIP file
                         </button>
                     </div>
                 </div>
@@ -931,7 +930,7 @@
                             <path
                                 d="M8.646 6.646a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1 0 .708l-2 2a.5.5 0 0 1-.708-.708L10.293 9 8.646 7.354a.5.5 0 0 1 0-.708m-1.292 0a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0 0 .708l2 2a.5.5 0 0 0 .708-.708L5.707 9l1.647-1.646a.5.5 0 0 0 0-.708z" />
                         </svg>
-                        xml
+                        Podlove Simple Chapters XML
                         <button class="btn btn-sm btn-outline-secondary icon-link ms-auto" id="copyPodloveButton">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                                 class="bi bi-clipboard2-check" viewBox="0 0 16 16" aria-hidden="true">
@@ -970,7 +969,7 @@
                             <path
                                 d="M8.646 6.646a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1 0 .708l-2 2a.5.5 0 0 1-.708-.708L10.293 9 8.646 7.354a.5.5 0 0 1 0-.708m-1.292 0a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0 0 .708l2 2a.5.5 0 0 0 .708-.708L5.707 9l1.647-1.646a.5.5 0 0 0 0-.708z" />
                         </svg>
-                        json
+                        Podcast Namespace JSON
                         <button class="btn btn-sm btn-outline-secondary icon-link ms-auto" id="copyJSONButton">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                                 class="bi bi-clipboard2-check" viewBox="0 0 16 16" aria-hidden="true">

--- a/src/ChapterList.js
+++ b/src/ChapterList.js
@@ -114,7 +114,7 @@ export class ChapterList {
         this.chapters.forEach(chapter => {
             if (!chapter.error) {
                 const chapterObject = {
-                    startTime: secondsToString(chapter.start),
+                    startTime: chapter.start / 1000,
                     title: chapter.title,
                 };
                 if (chapter.url) {


### PR DESCRIPTION
The Podcast Namespace JSON [chapter format](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) takes start times in seconds rather than`[hh:]mm:ss[.fff]` formatted timestamps.

Also puts `Podlove XML` before `Podcast Namespace JSON` in the documentation to match the page layout.